### PR TITLE
Airpump_turns_on_in_Waterphase_to_fight_overpressure

### DIFF
--- a/arduino_code/Quest_CLI/Quest_Flight.ino
+++ b/arduino_code/Quest_CLI/Quest_Flight.ino
@@ -232,9 +232,7 @@ void setup_water_phase()
     digitalWrite(WATERPUMP_PIN, LOW);
     
     //Turn on the Airpump backwards to fight overpressure
-    digitalWrite(AIRPUMP_F_PIN, HIGH); // Turn on Airpump backward
-    digitalWrite(AIRPUMP_B_PIN, LOW);  // Turn on Airpump backward
-    Serial.println("Airpump ON backwards")
+    set_pump_state(AIR_BACKWARD_PHASE);
 
     // Disable vibration
     Vibration_enable = false;
@@ -257,9 +255,9 @@ void setup_mix_phase()
     Serial.println("Waterpump OFF");
     digitalWrite(WATERPUMP_PIN, HIGH);
     
-    // Turn off the Airpump
-    digitalWrite(AIRPUMP_F_PIN, HIGH);  // Turn off Airpump
-    digitalWrite(AIRPUMP_B_PIN, HIGH);  // Turn off Airpump
+    // Disable airpump
+    Airpump_enable = false; // in this phase the airpump should not turn on
+    set_pump_state(AIR_WAIT_PHASE);
 
     // Enable vibration
     Serial.print("reading BME680: ");
@@ -269,10 +267,6 @@ void setup_mix_phase()
     Vibration_time = 0;                                         // Makes it initially direcly hit the phase switch of phase 0
     Vibration_phase_durations_ms[VIB_ON_PHASE] = 500;           // 0.5s ON
     Vibration_phase_durations_ms[VIB_OFF_PHASE] = 20 * one_sec; // 20s OFF
-
-    // Disable airpump
-    Airpump_enable = false; // in this phase the airpump should not turn on
-    set_pump_state(AIR_WAIT_PHASE);
 
     // Set new Phototime
     Photo_time = 20 * one_sec; // take photo every 20 seconds

--- a/arduino_code/Quest_CLI/Quest_Flight.ino
+++ b/arduino_code/Quest_CLI/Quest_Flight.ino
@@ -230,6 +230,11 @@ void setup_water_phase()
     // Turn on the Waterpump (for 30 sec)
     Serial.println("Waterpump ON");
     digitalWrite(WATERPUMP_PIN, LOW);
+    
+    //Turn on the Airpump backwards to fight overpressure
+    digitalWrite(AIRPUMP_F_PIN, HIGH); // Turn on Airpump backward
+    digitalWrite(AIRPUMP_B_PIN, LOW);  // Turn on Airpump backward
+    Serial.println("Airpump ON backwards")
 
     // Disable vibration
     Vibration_enable = false;
@@ -251,6 +256,10 @@ void setup_mix_phase()
     // Turn off the Waterpump
     Serial.println("Waterpump OFF");
     digitalWrite(WATERPUMP_PIN, HIGH);
+    
+    // Turn off the Airpump
+    digitalWrite(AIRPUMP_F_PIN, HIGH);  // Turn off Airpump
+    digitalWrite(AIRPUMP_B_PIN, HIGH);  // Turn off Airpump
 
     // Enable vibration
     Serial.print("reading BME680: ");


### PR DESCRIPTION
The Airpump now gets turned off backwards at the same time as the Waterpump and gets turned off at the same time as the Waterpump to fight overpressure.